### PR TITLE
Fix error message 'Only variables should be passed by reference'

### DIFF
--- a/src/Anchu/Ftp/Ftp.php
+++ b/src/Anchu/Ftp/Ftp.php
@@ -159,7 +159,8 @@ class Ftp {
      */
     public function downloadFile ($fileFrom, $fileTo)
     {
-        $extension = end(explode('.', $fileFrom));
+        $fileInfos = explode('.', $fileFrom);
+        $extension = end($fileInfos);
 
         $mode = $this->findTransferModeForExtension($extension);
         


### PR DESCRIPTION
This error occurs when you try to download a file 
