### PR TITLE
Added timeout to ftp connect and fixed connectionId bug

### DIFF
--- a/src/Anchu/Ftp/Ftp.php
+++ b/src/Anchu/Ftp/Ftp.php
@@ -30,11 +30,15 @@ class Ftp {
     {
         if(!isset($config['port']))
             $config['port'] = 21;
+        if(!isset($config['timeout']))
+            $config['timeout'] = 30;
 
-        $connectionId = ftp_connect($config['host'],$config['port']);
-        $loginResponse = ftp_login($connectionId, $config['username'], $config['password']);
-        ftp_pasv($connectionId, $config['passive']);
-        ftp_set_option($connectionId, FTP_TIMEOUT_SEC, 300);
+        $connectionId = ftp_connect($config['host'],$config['port'],$config['timeout']);
+        if ($connectionId) {
+            $loginResponse = ftp_login($connectionId, $config['username'], $config['password']);
+            ftp_pasv($connectionId, $config['passive']);
+            ftp_set_option($connectionId, FTP_TIMEOUT_SEC, 300);
+        }
 
         if ((!$connectionId) || (!$loginResponse))
             throw new \Exception('FTP connection has failed!');

--- a/src/Anchu/Ftp/Ftp.php
+++ b/src/Anchu/Ftp/Ftp.php
@@ -31,7 +31,7 @@ class Ftp {
         if(!isset($config['port']))
             $config['port'] = 21;
         if(!isset($config['timeout']))
-            $config['timeout'] = 30;
+            $config['timeout'] = 90;
 
         $connectionId = ftp_connect($config['host'],$config['port'],$config['timeout']);
         if ($connectionId) {

--- a/src/Anchu/Ftp/Ftp.php
+++ b/src/Anchu/Ftp/Ftp.php
@@ -37,7 +37,6 @@ class Ftp {
         if ($connectionId) {
             $loginResponse = ftp_login($connectionId, $config['username'], $config['password']);
             ftp_pasv($connectionId, $config['passive']);
-            ftp_set_option($connectionId, FTP_TIMEOUT_SEC, 300);
         }
 
         if ((!$connectionId) || (!$loginResponse))


### PR DESCRIPTION
The default connection timeout is 90 which is really long for most cases.  Added ability to set the timeout before the connection id is retrieved.

Also, if it does timeout, ftp_login throws an error because the first parameter is incorrect, so now it checks before attempting to login.