### PR TITLE
Added getDirListDetailed method

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ Returns a list of files in the given directory
  - `$directory`: The directory to be listed. Default value: `.`.
  - `$parameters`: Optional parameters to prefix with directory. For example: `-la`. Default: `null`.
 
+**getDirListingDetailed($directory)**
+
+Returns a list of files in the given directory as an associative array with the following keys:
+rights, number, user, group, size, month, day and time
+
+ - `$directory`: The directory to be listed. Default value: `.`.
+
 **makeDir($directory)**
 
 Creates the specified directory on the FTP server.

--- a/src/Anchu/Ftp/Ftp.php
+++ b/src/Anchu/Ftp/Ftp.php
@@ -79,6 +79,47 @@ class Ftp {
     }
 
     /**
+     * Get directory listing (detailed)
+     *
+     * @param string $directory
+     *
+     * @return array|bool
+     *
+     * @see      https://php.net/manual/de/function.ftp-rawlist.php#110803
+     *
+     */
+    public function getDirListingDetailed($directory = '.')
+    {
+        if (is_array($children = @ftp_rawlist($this->connectionId, $directory))) {
+            $items = array();
+
+            foreach ($children as $child) {
+                $chunks = preg_split("/\s+/", $child);
+                list(
+                    $item['rights'],
+                    $item['number'],
+                    $item['user'],
+                    $item['group'],
+                    $item['size'],
+                    $item['month'],
+                    $item['day'],
+                    $item['time']
+                ) = $chunks;
+
+                $item['type'] = $chunks[0]{0} === 'd' ? 'directory' : 'file';
+                array_splice($chunks, 0, 8);
+
+                $items[implode(" ", $chunks)] = $item;
+            }
+
+            return $items;
+        }
+
+        return false;
+
+    }
+
+    /**
      * Create new directory
      *
      * @param $directory


### PR DESCRIPTION
I needed to have a method that can list a directory's contents and lets me easily check, if a given entry is a file or directory.

This new method returns the output of the ftp_rawlist command as an associative array.